### PR TITLE
Use 'tool:pytest' in place of 'pytest' in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bdist_wheel]
 universal=1
 
-[pytest]
+[tool:pytest]
 norecursedirs = .git .* *.egg* old docs dist build
 addopts = -rw


### PR DESCRIPTION
The use of 'pytest' was deprecated in pytest 3, and removed in pytest 4.
See pytest-dev/pytest#3086.

See also [RHBZ#1716494](https://bugzilla.redhat.com/1716494).

I tested this change with pytest 3.4.2, 3.6.4, 3.9.3 and 4.4.1.