### PR TITLE
Catch ImportError

### DIFF
--- a/tests/test_stdin.py
+++ b/tests/test_stdin.py
@@ -1,8 +1,15 @@
 """Tests for polyfill's stdin monkey patching."""
 import flake8
-import pep8
-import pycodestyle
 import pytest
+try:
+    import pep8
+except ImportError:
+    pep8 = None
+
+try:
+    import pycodestyle
+except ImportError:
+    pycodestyle = None
 
 from flake8_polyfill import stdin
 from flake8_polyfill import version

--- a/tests/test_stdin.py
+++ b/tests/test_stdin.py
@@ -1,6 +1,7 @@
 """Tests for polyfill's stdin monkey patching."""
 import flake8
 import pytest
+
 try:
     import pep8
 except ImportError:


### PR DESCRIPTION
The handling is probably incorrect, but on the platforms I'm testing on this test is skipped anyway -- this just allows a simple `python -m pytest` to succeed
(Pushing this mainly for historical interest -- as noted elsewhere, this project appears to be deprecated)
